### PR TITLE
Add edge case handling

### DIFF
--- a/src/emvqr.ts
+++ b/src/emvqr.ts
@@ -22,36 +22,20 @@ const read = (text: string, tagId?: string, subData=false): ParsedQR | NestedDat
     return {};
   }
 
-  if (tagId === '62' && id === '00') {
-    custom = true;
-  } else if (tagId !== '62' && !subData) {
-    custom = false;
-  }
-
   let tag
-  let subtag
   if (custom) {
     tag = getCustomTag(id);
-    if (!tagId && !tag) return {};
-
-    subtag = getCustomSubtag(tagId!, id);
-
   } else {
     tag = getTag(id);
-    if (!tagId && !tag) return {};
-
-    subtag = getSubTag(tagId!, id);
   }
 
-  if (tagId && !subtag) {
-    return {};
-  }
+  if (!tagId && !tag) return {};
 
-  const subdata = read(data, id, true);
+  const subdata = isSubDataId(id) ? readSubData(data, id) : {};
 
   const value = {
     id,
-    name: subtag ? subtag.name : tag!.name,
+    name: tag!.name,
     len,
     data: Object.keys(subdata).length ? subdata : data,
   };
@@ -66,6 +50,67 @@ const read = (text: string, tagId?: string, subData=false): ParsedQR | NestedDat
       [id]: value,
     };
   }
+};
+
+const readSubData = (text: string, tagId: string, custom?:boolean): ParsedQR | NestedData => {
+  if (text.length < 3) {
+    return {};
+  }
+
+  const id = text.substring(0, 2);
+  const len = parseInt(text.substring(2, 4), 10);
+
+  if (!len) {
+    return {};
+  }
+
+  const data = text.substring(4, len + 4);
+  const next = text.substring(len + 4);
+
+  if (!data.length || len !== data.length) {
+    return {};
+  }
+
+  let cust
+  if (tagId === '62' && id === '00') {
+    cust = true;
+  } else if (tagId !== '62') {
+    cust = false;
+  }
+
+  cust = custom ?? cust
+
+  let subtag
+  if (cust) {
+    subtag = getCustomSubtag(tagId, id);
+  } else {
+    subtag = getSubTag(tagId, id);
+  }
+  
+  if (!subtag) return {};
+
+  const value = {
+    id,
+    name: subtag!.name,
+    len,
+    data: data,
+  };
+
+  if (next.length) {
+    return {
+      [id]: value,
+      ...readSubData(next, tagId, cust),
+    };
+  } else {
+    return {
+      [id]: value,
+    };
+  }
+};
+
+const isSubDataId = (id: string) => {
+  const intId = parseInt(id, 10);
+  return (intId >= 2 && intId <= 51) || intId === 62 || intId === 64 || (intId >= 65 && intId <= 99);
 };
 
 export const decodeQrData = (text: string): ParsedQR => {


### PR DESCRIPTION
if the value of the data of a nested data object just so happens to be a valid EMVCO format (e.g. 0306198273981237, where 03 is a valid number for all nested data object, with 6 being a valid length as there are more than 6 characters after '06'), it will return an error